### PR TITLE
Fix typo in examples

### DIFF
--- a/examples/src/main/kotlin/LongPollingExample.kt
+++ b/examples/src/main/kotlin/LongPollingExample.kt
@@ -7,7 +7,7 @@ fun main() {
         // below is optional parameters
         // limit = 50
         // timeout = 30
-        // allowedUpdates = listOf(AllowedUpdates.Message)
+        // allowedUpdates = listOf(AllowedUpdate.Message)
         // removeWebhookAutomatically = true
         // period = 1000
     }

--- a/examples/src/main/kotlin/WebhookExample.kt
+++ b/examples/src/main/kotlin/WebhookExample.kt
@@ -9,7 +9,7 @@ fun main() {
         // below is optional parameters
         // certificate = Paths.get("<PATH TO CERTIFICATE>").toFile()
         // maxConnections = 20
-        // allowedUpdates = listOf(AllowedUpdates.Message)
+        // allowedUpdates = listOf(AllowedUpdate.Message)
         // setWebhookAutomatically = true
 
         /*


### PR DESCRIPTION
IDE couldn't find any class to import after uncommenting the example. It turned out to be a misstype.