### PR TITLE
#39 fix type

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "1.3.8"
+version = "1.3.9"
 
 plugins {
     id("com.github.johnrengelman.shadow") version "5.2.0"

--- a/library/src/main/kotlin/com/elbekD/bot/types/general.kt
+++ b/library/src/main/kotlin/com/elbekD/bot/types/general.kt
@@ -39,7 +39,7 @@ public data class WebhookInfo(
 )
 
 public data class User(
-    val id: Int,
+    val id: Long,
     val is_bot: Boolean,
     val first_name: String,
     val last_name: String?,


### PR DESCRIPTION
According to https://core.telegram.org/bots/api#user, 32-bit Int is not enough.

> Unique identifier for this user or bot. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.