### PR TITLE
Type safe sending documents

### DIFF
--- a/library/src/main/kotlin/com/elbekd/bot/api/TelegramApi.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/api/TelegramApi.kt
@@ -3,6 +3,7 @@ package com.elbekd.bot.api
 import com.elbekd.bot.model.ChatId
 import com.elbekd.bot.types.*
 import com.elbekd.bot.util.Action
+import com.elbekd.bot.util.SendingDocument
 
 public interface TelegramApi :
     TelegramInlineModeApi,
@@ -73,7 +74,7 @@ public interface TelegramApi :
 
     public suspend fun sendPhoto(
         chatId: ChatId,
-        photo: Any,
+        photo: SendingDocument,
         caption: String? = null,
         parseMode: ParseMode? = null,
         captionEntities: List<MessageEntity>? = null,
@@ -86,7 +87,7 @@ public interface TelegramApi :
 
     public suspend fun sendAudio(
         chatId: ChatId,
-        audio: Any,
+        audio: SendingDocument,
         caption: String? = null,
         parseMode: ParseMode? = null,
         captionEntities: List<MessageEntity>? = null,
@@ -103,7 +104,7 @@ public interface TelegramApi :
 
     public suspend fun sendDocument(
         chatId: ChatId,
-        document: Any,
+        document: SendingDocument,
         thumb: java.io.File? = null,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -118,7 +119,7 @@ public interface TelegramApi :
 
     public suspend fun sendVideo(
         chatId: ChatId,
-        video: Any,
+        video: SendingDocument,
         duration: Long? = null,
         width: Long? = null,
         height: Long? = null,
@@ -136,7 +137,7 @@ public interface TelegramApi :
 
     public suspend fun sendAnimation(
         chatId: ChatId,
-        animation: Any,
+        animation: SendingDocument,
         duration: Long? = null,
         width: Long? = null,
         height: Long? = null,
@@ -153,7 +154,7 @@ public interface TelegramApi :
 
     public suspend fun sendVoice(
         chatId: ChatId,
-        voice: Any,
+        voice: SendingDocument,
         caption: String? = null,
         parseMode: ParseMode? = null,
         captionEntities: List<MessageEntity>? = null,
@@ -167,7 +168,7 @@ public interface TelegramApi :
 
     public suspend fun sendVideoNote(
         chatId: ChatId,
-        note: Any,
+        note: SendingDocument,
         duration: Long? = null,
         length: Long? = null,
         thumb: java.io.File? = null,

--- a/library/src/main/kotlin/com/elbekd/bot/internal/TelegramBot.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/internal/TelegramBot.kt
@@ -5,6 +5,7 @@ import com.elbekd.bot.model.ChatId
 import com.elbekd.bot.types.*
 import com.elbekd.bot.util.Action
 import com.elbekd.bot.util.AllowedUpdate
+import com.elbekd.bot.util.SendingDocument
 import java.io.File
 
 internal abstract class TelegramBot protected constructor(username: String?, tk: String) : Bot {
@@ -224,7 +225,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendPhoto(
         chatId: ChatId,
-        photo: Any,
+        photo: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -248,7 +249,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendAudio(
         chatId: ChatId,
-        audio: Any,
+        audio: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -280,7 +281,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendDocument(
         chatId: ChatId,
-        document: Any,
+        document: SendingDocument,
         thumb: File?,
         caption: String?,
         parseMode: ParseMode?,
@@ -308,7 +309,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendVideo(
         chatId: ChatId,
-        video: Any,
+        video: SendingDocument,
         duration: Long?,
         width: Long?,
         height: Long?,
@@ -342,7 +343,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendAnimation(
         chatId: ChatId,
-        animation: Any,
+        animation: SendingDocument,
         duration: Long?,
         width: Long?,
         height: Long?,
@@ -374,7 +375,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendVoice(
         chatId: ChatId,
-        voice: Any,
+        voice: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -400,7 +401,7 @@ internal abstract class TelegramBot protected constructor(username: String?, tk:
 
     override suspend fun sendVideoNote(
         chatId: ChatId,
-        note: Any,
+        note: SendingDocument,
         duration: Long?,
         length: Long?,
         thumb: File?,

--- a/library/src/main/kotlin/com/elbekd/bot/internal/TelegramClient.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/internal/TelegramClient.kt
@@ -7,6 +7,10 @@ import com.elbekd.bot.model.internal.*
 import com.elbekd.bot.types.*
 import com.elbekd.bot.util.Action
 import com.elbekd.bot.util.AllowedUpdate
+import com.elbekd.bot.util.SendingByteArray
+import com.elbekd.bot.util.SendingDocument
+import com.elbekd.bot.util.SendingFile
+import com.elbekd.bot.util.SendingString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
@@ -98,7 +102,7 @@ internal class TelegramClient(token: String) : TelegramApi {
     private suspend fun sendFile(
         type: String,
         chatId: ChatId,
-        file: Any,
+        file: SendingDocument,
         opts: Map<String, Any?>,
         thumb: File? = null,
         method: String = type
@@ -107,12 +111,12 @@ internal class TelegramClient(token: String) : TelegramApi {
         form.addFormDataPart(ApiConstants.CHAT_ID, chatId.toString())
         addOptsToForm(form, opts)
 
-        when (file) {
-            is ByteArray -> form.addFormDataPart(type, "content", file.toRequestBody(null))
-            is File -> form.addFormDataPart(type, file.name, file.asRequestBody(null))
-            is String -> form.addFormDataPart(type, file)
-            else -> throw IllegalArgumentException("Unsupported file object. Supported types: ByteArray, File, String.")
+        val content = when (file) {
+            is SendingByteArray -> file.content.toRequestBody(null)
+            is SendingString -> file.content.toRequestBody(null)
+            is SendingFile -> file.file.asRequestBody(null)
         }
+        form.addFormDataPart(type, file.fileName, content)
 
         thumb?.let {
             form.addFormDataPart("attach://${it.name}", it.name, it.asRequestBody(null))
@@ -363,7 +367,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendPhoto(
         chatId: ChatId,
-        photo: Any,
+        photo: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -392,7 +396,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendAudio(
         chatId: ChatId,
-        audio: Any,
+        audio: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -429,7 +433,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendDocument(
         chatId: ChatId,
-        document: Any,
+        document: SendingDocument,
         thumb: File?,
         caption: String?,
         parseMode: ParseMode?,
@@ -462,7 +466,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendVideo(
         chatId: ChatId,
-        video: Any,
+        video: SendingDocument,
         duration: Long?,
         width: Long?,
         height: Long?,
@@ -501,7 +505,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendAnimation(
         chatId: ChatId,
-        animation: Any,
+        animation: SendingDocument,
         duration: Long?,
         width: Long?,
         height: Long?,
@@ -538,7 +542,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendVoice(
         chatId: ChatId,
-        voice: Any,
+        voice: SendingDocument,
         caption: String?,
         parseMode: ParseMode?,
         captionEntities: List<MessageEntity>?,
@@ -569,7 +573,7 @@ internal class TelegramClient(token: String) : TelegramApi {
 
     override suspend fun sendVideoNote(
         chatId: ChatId,
-        note: Any,
+        note: SendingDocument,
         duration: Long?,
         length: Long?,
         thumb: File?,

--- a/library/src/main/kotlin/com/elbekd/bot/util/SendingDocument.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/util/SendingDocument.kt
@@ -1,0 +1,22 @@
+package com.elbekd.bot.util
+
+import java.io.File
+
+public sealed class SendingDocument {
+    public abstract val fileName: String?
+}
+
+public class SendingByteArray(
+    public val content: ByteArray,
+    public override val fileName: String? = null,
+) : SendingDocument()
+
+public class SendingString(
+    public val content: String,
+    public override val fileName: String? = null,
+) : SendingDocument()
+
+public class SendingFile(public val file: File) : SendingDocument() {
+    override val fileName: String
+        get() = file.name
+}


### PR DESCRIPTION
This Pull Request brings:

- Type safe sending documents
- Moreover, you can now send `ByteArray` with a custom name (previously in order to send a `ByteArray` with a custom name you had to save it as a file with a needed name and then pass the file as a parameter, not that convenient)