### PR TITLE
Fixing ChatMember serialization bug

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.github.johnrengelman.shadow") version "5.2.0"
@@ -30,6 +31,10 @@ kotlin {
 
 tasks.withType<Jar> {
     buildDir = rootProject.buildDir
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
 }
 
 tasks {

--- a/library/src/main/kotlin/com/elbekd/bot/types/chat.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/types/chat.kt
@@ -2,6 +2,7 @@ package com.elbekd.bot.types
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 @Serializable
 public data class Chat(
@@ -55,7 +56,9 @@ public data class ChatPhoto(
 )
 
 @Serializable
+@JsonClassDiscriminator("status")
 public sealed class ChatMember {
+    @SerialName("creator")
     public data class Owner(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User,
@@ -63,6 +66,7 @@ public sealed class ChatMember {
         @SerialName("custom_title") val customTitle: String? = null
     ) : ChatMember()
 
+    @SerialName("administrator")
     public data class Administrator(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User,
@@ -82,12 +86,14 @@ public sealed class ChatMember {
     ) : ChatMember()
 
     @Serializable
+    @SerialName("member")
     public data class Member(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User
     ) : ChatMember()
 
     @Serializable
+    @SerialName("restricted")
     public data class Restricted(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User,
@@ -104,12 +110,14 @@ public sealed class ChatMember {
     ) : ChatMember()
 
     @Serializable
+    @SerialName("left")
     public data class Left(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User
     ) : ChatMember()
 
     @Serializable
+    @SerialName("kicked")
     public data class Banned(
         @SerialName("status") val status: String,
         @SerialName("user") val user: User,


### PR DESCRIPTION
We've tried to block and unblock bot and the logs of bot went crazy, there was one constant unstoppable error:

```
kotlinx.serialization.json.internal.JsonDecodingException: Polymorphic serializer was not found for missing class discriminator ('null')
JSON input: {"user":{"id":12...5,"is_bot":true,"first_name":"name","username":"username"},"status":"member"}
```

It reduced to the following code failing with the sam issue:

```kotlin
val json = "{\"user\":{\"id\":120,\"is_bot\":true,\"first_name\":\"name\",\"username\":\"username\"},\"status\":\"member\"}"
println(Json.decodeFromString<ChatMember>(json))
```

So the problem was that there was no information that can be used to determine which subclass of `ChatMember` to use in deserialization. This information contains in field `status` (in documentation: `ChatMemberOwner`, status - The member's status in the chat, always "creator"; and other "always" values for each type).

Now the above kotlin code runs successfully.