### PR TITLE
Fixing ChatId descriptor bug

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -35,6 +35,7 @@ tasks.withType<Jar> {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.serialization.InternalSerializationApi"
 }
 
 tasks {

--- a/library/src/main/kotlin/com/elbekd/bot/model/internal/serializers.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/model/internal/serializers.kt
@@ -2,15 +2,14 @@ package com.elbekd.bot.model.internal
 
 import com.elbekd.bot.model.ChatId
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 internal class ChatIdSerializer : KSerializer<ChatId> {
-    private val strategy by lazy { ChatId.serializer() }
 
-    override val descriptor: SerialDescriptor
-        get() = strategy.descriptor
+    override val descriptor = buildSerialDescriptor("ChatIdSerializer", PolymorphicKind.SEALED)
 
     override fun deserialize(decoder: Decoder): ChatId {
         try {


### PR DESCRIPTION
 Most of the time `ChatId` is serialized successfully, and the `descriptor` field of `ChatIdSerializer` is not used.

But I was trying `editMessageReplyMarkup` method and `ChatId` there is optional. \
Therefore, it stumbled upon the following line in `kotlinx.serialization`: [kotlinx/serialization/encoding/Encoding.kt#L291](https://github.com/Kotlin/kotlinx.serialization/blob/v1.3.3/core/commonMain/src/kotlinx/serialization/encoding/Encoding.kt#L291) and there was stack overflow error trying to get the descriptor:

```
at com.elbekd.bot.model.internal.ChatIdSerializer.getDescriptor(serializers.kt:13)
at com.elbekd.bot.model.internal.ChatIdSerializer.getDescriptor(serializers.kt:13)
```

There is [Content-based polymorphic deserialization](https://github.com/Kotlin/kotlinx.serialization/blob/v1.3.3/docs/json.md#content-based-polymorphic-deserialization) in `kotlinx.serialization` that could be used here, but this would lead to more boilerplate code (because it would require `ChatId.StringId` and `ChatId.IntegerId` to be serializable and a custom serializer class for each). So I just copied the descriptor implementation from `JsonContentPolymorphicSerializer` class here and it works now.
