### PR TITLE
InlineQueryResult serialization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.1.6
+- `InlineQueryResult` serialization fix
+
 ## Version 2.1.5
 - Update Bot API to 6.1
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -53,7 +53,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.elbekd"
             artifactId = "kt-telegram-bot"
-            version = "2.1.5"
+            version = "2.1.6"
 
             from(components["java"])
         }

--- a/library/src/main/kotlin/com/elbekd/bot/model/internal/serializers.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/model/internal/serializers.kt
@@ -1,8 +1,38 @@
 package com.elbekd.bot.model.internal
 
 import com.elbekd.bot.model.ChatId
+import com.elbekd.bot.types.InlineQueryResult
+import com.elbekd.bot.types.InlineQueryResultArticle
+import com.elbekd.bot.types.InlineQueryResultAudio
+import com.elbekd.bot.types.InlineQueryResultCachedAudio
+import com.elbekd.bot.types.InlineQueryResultCachedDocument
+import com.elbekd.bot.types.InlineQueryResultCachedGif
+import com.elbekd.bot.types.InlineQueryResultCachedMpeg4Gif
+import com.elbekd.bot.types.InlineQueryResultCachedPhoto
+import com.elbekd.bot.types.InlineQueryResultCachedSticker
+import com.elbekd.bot.types.InlineQueryResultCachedVideo
+import com.elbekd.bot.types.InlineQueryResultCachedVoice
+import com.elbekd.bot.types.InlineQueryResultContact
+import com.elbekd.bot.types.InlineQueryResultDocument
+import com.elbekd.bot.types.InlineQueryResultGame
+import com.elbekd.bot.types.InlineQueryResultGif
+import com.elbekd.bot.types.InlineQueryResultLocation
+import com.elbekd.bot.types.InlineQueryResultMpeg4Gif
+import com.elbekd.bot.types.InlineQueryResultPhoto
+import com.elbekd.bot.types.InlineQueryResultVenue
+import com.elbekd.bot.types.InlineQueryResultVideo
+import com.elbekd.bot.types.InlineQueryResultVoice
+import com.elbekd.bot.types.InputContactMessageContent
+import com.elbekd.bot.types.InputInvoiceMessageContent
+import com.elbekd.bot.types.InputLocationMessageContent
+import com.elbekd.bot.types.InputMessageContent
+import com.elbekd.bot.types.InputTextMessageContent
+import com.elbekd.bot.types.InputVenueMessageContent
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -31,6 +61,79 @@ internal class ChatIdSerializer : KSerializer<ChatId> {
         when (value) {
             is ChatId.IntegerId -> encoder.encodeLong(value.id)
             is ChatId.StringId -> encoder.encodeString(value.id)
+        }
+    }
+}
+
+@Serializer(forClass = InlineQueryResult::class)
+internal object InlineQueryResultSerializer : SerializationStrategy<InlineQueryResult> {
+
+    override val descriptor = buildSerialDescriptor("InlineQueryResultSerializer", PolymorphicKind.SEALED)
+
+    override fun serialize(encoder: Encoder, value: InlineQueryResult) {
+        when (value) {
+            is InlineQueryResultArticle ->
+                encoder.encodeSerializableValue(InlineQueryResultArticle.serializer(), value)
+            is InlineQueryResultPhoto ->
+                encoder.encodeSerializableValue(InlineQueryResultPhoto.serializer(), value)
+            is InlineQueryResultGif ->
+                encoder.encodeSerializableValue(InlineQueryResultGif.serializer(), value)
+            is InlineQueryResultMpeg4Gif ->
+                encoder.encodeSerializableValue(InlineQueryResultMpeg4Gif.serializer(), value)
+            is InlineQueryResultVideo ->
+                encoder.encodeSerializableValue(InlineQueryResultVideo.serializer(), value)
+            is InlineQueryResultAudio ->
+                encoder.encodeSerializableValue(InlineQueryResultAudio.serializer(), value)
+            is InlineQueryResultVoice ->
+                encoder.encodeSerializableValue(InlineQueryResultVoice.serializer(), value)
+            is InlineQueryResultDocument ->
+                encoder.encodeSerializableValue(InlineQueryResultDocument.serializer(), value)
+            is InlineQueryResultLocation ->
+                encoder.encodeSerializableValue(InlineQueryResultLocation.serializer(), value)
+            is InlineQueryResultVenue ->
+                encoder.encodeSerializableValue(InlineQueryResultVenue.serializer(), value)
+            is InlineQueryResultContact ->
+                encoder.encodeSerializableValue(InlineQueryResultContact.serializer(), value)
+            is InlineQueryResultGame ->
+                encoder.encodeSerializableValue(InlineQueryResultGame.serializer(), value)
+            is InlineQueryResultCachedPhoto ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedPhoto.serializer(), value)
+            is InlineQueryResultCachedGif ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedGif.serializer(), value)
+            is InlineQueryResultCachedMpeg4Gif ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedMpeg4Gif.serializer(), value)
+            is InlineQueryResultCachedSticker ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedSticker.serializer(), value)
+            is InlineQueryResultCachedDocument ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedDocument.serializer(), value)
+            is InlineQueryResultCachedVideo ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedVideo.serializer(), value)
+            is InlineQueryResultCachedVoice ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedVoice.serializer(), value)
+            is InlineQueryResultCachedAudio ->
+                encoder.encodeSerializableValue(InlineQueryResultCachedAudio.serializer(), value)
+        }
+    }
+}
+
+@Serializer(forClass = InputMessageContent::class)
+internal object InputMessageContentSerializer : SerializationStrategy<InputMessageContent> {
+
+    override val descriptor: SerialDescriptor =
+        buildSerialDescriptor("InputMessageContentSerializer", PolymorphicKind.SEALED)
+
+    override fun serialize(encoder: Encoder, value: InputMessageContent) {
+        when (value) {
+            is InputTextMessageContent ->
+                encoder.encodeSerializableValue(InputTextMessageContent.serializer(), value)
+            is InputLocationMessageContent ->
+                encoder.encodeSerializableValue(InputLocationMessageContent.serializer(), value)
+            is InputVenueMessageContent ->
+                encoder.encodeSerializableValue(InputVenueMessageContent.serializer(), value)
+            is InputContactMessageContent ->
+                encoder.encodeSerializableValue(InputContactMessageContent.serializer(), value)
+            is InputInvoiceMessageContent ->
+                encoder.encodeSerializableValue(InputInvoiceMessageContent.serializer(), value)
         }
     }
 }

--- a/library/src/main/kotlin/com/elbekd/bot/types/inline.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/types/inline.kt
@@ -1,5 +1,8 @@
 package com.elbekd.bot.types
 
+import com.elbekd.bot.model.internal.InlineQueryResultSerializer
+import com.elbekd.bot.model.internal.InputMessageContentSerializer
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,13 +16,13 @@ public data class InlineQuery(
     @SerialName("location") val location: Location? = null
 )
 
-@Serializable
-public sealed class InlineQueryResult(
-    @SerialName("type") public val type: String
-)
+@Serializable(with = InlineQueryResultSerializer::class)
+public sealed class InlineQueryResult {
+    @SerialName("type")
+    public abstract val type: String
+}
 
 @Serializable
-@SerialName("article")
 public data class InlineQueryResultArticle(
     @SerialName("id") val id: String,
     @SerialName("title") val title: String,
@@ -30,11 +33,14 @@ public data class InlineQueryResultArticle(
     @SerialName("description") val description: String? = null,
     @SerialName("thumb_url") val thumbUrl: String? = null,
     @SerialName("thumb_width") val thumbWidth: Int? = null,
-    @SerialName("thumb_height") val thumbHeight: Int? = null
-) : InlineQueryResult(type = "article")
+    @SerialName("thumb_height") val thumbHeight: Int? = null,
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "article"
+}
 
 @Serializable
-@SerialName("photo")
 public data class InlineQueryResultPhoto(
     @SerialName("id") val id: String,
     @SerialName("photo_url") val photoUrl: String,
@@ -48,10 +54,13 @@ public data class InlineQueryResultPhoto(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "photo")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "photo"
+}
 
 @Serializable
-@SerialName("gif")
 public data class InlineQueryResultGif(
     @SerialName("id") val id: String,
     @SerialName("gif_url") val gifUrl: String,
@@ -66,10 +75,13 @@ public data class InlineQueryResultGif(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "gif")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "gif"
+}
 
 @Serializable
-@SerialName("mpeg4_gif")
 public data class InlineQueryResultMpeg4Gif(
     @SerialName("id") val id: String,
     @SerialName("mpeg4_url") val mpeg4Url: String,
@@ -83,10 +95,13 @@ public data class InlineQueryResultMpeg4Gif(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "mpeg4_gif")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "mpeg4_gif"
+}
 
 @Serializable
-@SerialName("video")
 public data class InlineQueryResultVideo(
     @SerialName("id") val id: String,
     @SerialName("video_url") val videoUrl: String,
@@ -102,10 +117,13 @@ public data class InlineQueryResultVideo(
     @SerialName("description") val description: String? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "video")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "video"
+}
 
 @Serializable
-@SerialName("audio")
 public data class InlineQueryResultAudio(
     @SerialName("id") val id: String,
     @SerialName("audio_url") val audioUrl: String,
@@ -117,10 +135,13 @@ public data class InlineQueryResultAudio(
     @SerialName("audio_duration") val audioDuration: Int? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "audio")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "audio"
+}
 
 @Serializable
-@SerialName("voice")
 public data class InlineQueryResultVoice(
     @SerialName("id") val id: String,
     @SerialName("voice_url") val voiceUrl: String,
@@ -131,10 +152,13 @@ public data class InlineQueryResultVoice(
     @SerialName("voice_duration") val voiceDuration: Int? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "voice")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "voice"
+}
 
 @Serializable
-@SerialName("document")
 public data class InlineQueryResultDocument(
     @SerialName("id") val id: String,
     @SerialName("title") val title: String,
@@ -149,10 +173,13 @@ public data class InlineQueryResultDocument(
     @SerialName("thumb_url") val thumbUrl: String? = null,
     @SerialName("thumb_width") val thumbWidth: Int? = null,
     @SerialName("thumb_height") val thumbHeight: Int? = null
-) : InlineQueryResult(type = "document")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "document"
+}
 
 @Serializable
-@SerialName("location")
 public data class InlineQueryResultLocation(
     @SerialName("id") val id: String,
     @SerialName("latitude") val latitude: Float,
@@ -167,10 +194,13 @@ public data class InlineQueryResultLocation(
     @SerialName("thumb_url") val thumbUrl: String? = null,
     @SerialName("thumb_width") val thumbWidth: Int? = null,
     @SerialName("thumb_height") val thumbHeight: Int? = null
-) : InlineQueryResult(type = "location")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "location"
+}
 
 @Serializable
-@SerialName("venue")
 public data class InlineQueryResultVenue(
     @SerialName("id") val id: String,
     @SerialName("latitude") val latitude: Float,
@@ -186,10 +216,13 @@ public data class InlineQueryResultVenue(
     @SerialName("thumb_url") val thumbUrl: String? = null,
     @SerialName("thumb_width") val thumbWidth: Int? = null,
     @SerialName("thumb_height") val thumbHeight: Int? = null
-) : InlineQueryResult(type = "venue")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "venue"
+}
 
 @Serializable
-@SerialName("contact")
 public data class InlineQueryResultContact(
     @SerialName("id") val id: String,
     @SerialName("phone_number") val phoneNumber: String,
@@ -201,18 +234,24 @@ public data class InlineQueryResultContact(
     @SerialName("thumb_url") val thumbUrl: String? = null,
     @SerialName("thumb_width") val thumbWidth: Int? = null,
     @SerialName("thumb_height") val thumbHeight: Int? = null
-) : InlineQueryResult(type = "contact")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "contact"
+}
 
 @Serializable
-@SerialName("game")
 public data class InlineQueryResultGame(
     @SerialName("id") val id: String,
     @SerialName("game_short_name") val gameShortName: String,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null
-) : InlineQueryResult(type = "game")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "game"
+}
 
 @Serializable
-@SerialName("photo")
 public data class InlineQueryResultCachedPhoto(
     @SerialName("id") val id: String,
     @SerialName("photo_file_id") val photoFileId: String,
@@ -223,10 +262,13 @@ public data class InlineQueryResultCachedPhoto(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "photo")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "photo"
+}
 
 @Serializable
-@SerialName("gif")
 public data class InlineQueryResultCachedGif(
     @SerialName("id") val id: String,
     @SerialName("gif_file_id") val gifFileId: String,
@@ -236,10 +278,13 @@ public data class InlineQueryResultCachedGif(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "gif")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "gif"
+}
 
 @Serializable
-@SerialName("mpeg4_gif")
 public data class InlineQueryResultCachedMpeg4Gif(
     @SerialName("id") val id: String,
     @SerialName("mpeg4_file_id") val mpeg4FileId: String,
@@ -249,19 +294,25 @@ public data class InlineQueryResultCachedMpeg4Gif(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "mpeg4_gif")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "mpeg4_gif"
+}
 
 @Serializable
-@SerialName("sticker")
 public data class InlineQueryResultCachedSticker(
     @SerialName("id") val id: String,
     @SerialName("sticker_file_id") val stickerFileId: String,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "sticker")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "sticker"
+}
 
 @Serializable
-@SerialName("document")
 public data class InlineQueryResultCachedDocument(
     @SerialName("id") val id: String,
     @SerialName("title") val title: String,
@@ -272,10 +323,13 @@ public data class InlineQueryResultCachedDocument(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "document")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "document"
+}
 
 @Serializable
-@SerialName("video")
 public data class InlineQueryResultCachedVideo(
     @SerialName("id") val id: String,
     @SerialName("video_file_id") val videoFileId: String,
@@ -286,10 +340,13 @@ public data class InlineQueryResultCachedVideo(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "video")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "video"
+}
 
 @Serializable
-@SerialName("voice")
 public data class InlineQueryResultCachedVoice(
     @SerialName("id") val id: String,
     @SerialName("voice_file_id") val voiceFileId: String,
@@ -299,10 +356,13 @@ public data class InlineQueryResultCachedVoice(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "voice")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "voice"
+}
 
 @Serializable
-@SerialName("audio")
 public data class InlineQueryResultCachedAudio(
     @SerialName("id") val id: String,
     @SerialName("audio_file_id") val audioFileId: String,
@@ -311,9 +371,13 @@ public data class InlineQueryResultCachedAudio(
     @SerialName("caption_entities") val captionEntities: List<MessageEntity>? = null,
     @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
     @SerialName("input_message_content") val inputMessageContent: InputMessageContent? = null
-) : InlineQueryResult(type = "audio")
+) : InlineQueryResult() {
+    @EncodeDefault
+    @SerialName("type")
+    override val type: String = "audio"
+}
 
-@Serializable
+@Serializable(with = InputMessageContentSerializer::class)
 public sealed class InputMessageContent
 
 @Serializable


### PR DESCRIPTION
- Faced the following problem:
    `Multiple sealed subclasses of 'class com.elbekd.bot.types.InlineQueryResult' have the same serial name 'photo': 'class com.elbekd.bot.types.InlineQueryResultPhoto', 'class com.elbekd.bot.types.InlineQueryResultCachedPhoto'`
    Moreover, these `InlineQueryResult` classes don't need `deserialize` methods and don't need `type` field in serialization (by default, `kotlinx.serialization` uses it for deserialization and here it was an error: there is a collision - `type` field is used for type serialization, `type` field is needed by Telegram API) \
    The solution is getting rid of `type` by boilerplating serialization delegation and moving field `type` from `InlineQueryResult`'s constructor argument to body due to `Impossible to make this class serializable because its parent is not serializable and does not have exactly one constructor without parameters`

- Update version to `2.1.6`