### PR TITLE
feat: change Any to ReplyKeyboard for markupToString

### DIFF
--- a/library/src/main/kotlin/com/elbekd/bot/internal/TelegramClient.kt
+++ b/library/src/main/kotlin/com/elbekd/bot/internal/TelegramClient.kt
@@ -150,7 +150,7 @@ internal class TelegramClient(token: String) : TelegramApi {
     }
 
     private val anyToString = { a: Any -> a.toString(); }
-    private val markupToString = { a: Any -> toJson(a) }
+    private val markupToString = { a: ReplyKeyboard -> toJson(a) }
 
     private val sendFileOpts = mapOf(
         ApiConstants.CAPTION to anyToString,


### PR DESCRIPTION
Changed `Any` to `ReplyKeyboard` for `markupToString` since all markups uses object inherited by class `ReplyKeyboard`.